### PR TITLE
Docs: scope typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Access **Features > OAuth & Permissions** from the left sidebar and set the foll
 
 `https://api.slack.com/apps/{APP_ID}/oauth`
 
-* `app_mentioned:read`
+* `app_mentiones:read`
 * `chat:write`
 * `commands`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Access **Features > OAuth & Permissions** from the left sidebar and set the foll
 
 `https://api.slack.com/apps/{APP_ID}/oauth`
 
-* `app_mentiones:read`
+* `app_mentions:read`
 * `chat:write`
 * `commands`
 


### PR DESCRIPTION
Here's proof image:

![proof image](https://github.com/seratch/bolt-starter/raw/master/images/oauth_scopes.png)